### PR TITLE
feat: Add afilter, avalues, and avalues_list to QuerySet

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1450,6 +1450,14 @@ class QuerySet(AltersData):
         )
         return clone
 
+    async def avalues(self, *fields, **expressions):
+        """Return a list of dictionaries instead of a QuerySet."""
+        return [obj async for obj in self.values(*fields, **expressions)]
+
+    async def avalues_list(self, *fields, **kwargs):
+        """Return a list of tuples instead of a QuerySet."""
+        return [obj async for obj in self.values_list(*fields, **kwargs)]
+
     def dates(self, field_name, kind, order="ASC"):
         """
         Return a list of date objects representing all available dates for
@@ -1527,6 +1535,13 @@ class QuerySet(AltersData):
         """
         self._not_support_combined_queries("filter")
         return self._filter_or_exclude(False, args, kwargs)
+
+    def afilter(self, *args, **kwargs):
+        """
+        Return a new QuerySet instance with the args ANDed to the existing
+        set.
+        """
+        return self.filter(*args, **kwargs)
 
     def exclude(self, *args, **kwargs):
         """

--- a/tests/async/test_async_queryset.py
+++ b/tests/async/test_async_queryset.py
@@ -257,3 +257,18 @@ class AsyncQuerySetTest(TestCase):
         sql = "SELECT id, field FROM async_simplemodel WHERE created=%s"
         qs = SimpleModel.objects.raw(sql, [self.s1.created])
         self.assertEqual([o async for o in qs], [self.s1])
+
+    async def test_afilter(self):
+        qs = SimpleModel.objects.afilter(field=1)
+        self.assertEqual(await qs.acount(), 1)
+        self.assertEqual(await qs.afirst(), self.s1)
+
+    async def test_avalues(self):
+        data = await SimpleModel.objects.filter(field=1).avalues("field")
+        self.assertEqual(data, [{"field": 1}])
+
+    async def test_avalues_list_flat(self):
+        data = await SimpleModel.objects.filter(field=1).avalues_list(
+            "field", flat=True
+        )
+        self.assertEqual(data, [1])


### PR DESCRIPTION
This commit introduces three new methods to the QuerySet class to improve the asynchronous API:

- `afilter`: An alias for the `filter` method. Since `filter` is lazy and doesn't perform I/O, it doesn't need a true async implementation. This alias is added for API consistency and to match user expectations for async operations.

- `avalues`: An async method that evaluates a `values()` queryset and returns a list of dictionaries. It provides a convenient, awaitable alternative to asynchronously iterating over a `values()` queryset.

- `avalues_list`: An async method that evaluates a `values_list()` queryset and returns a list of tuples. Similar to `avalues`, it offers a direct, awaitable way to get results from a `values_list()` call in an async context.

Tests have been added for all three methods to ensure they function correctly.

#### Trac ticket number
<!-- Replace XXXXX with the corresponding Trac ticket number, or delete the line and write "N/A" if this is a trivial PR. -->

ticket-XXXXX

#### Branch description
Provide a concise overview of the issue or rationale behind the proposed changes.

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
